### PR TITLE
Fix usage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Now load the spoon from your Hammerspoon config:
 
 ```lua
 hs.loadSpoon('ControlEscMap')
-spoon.ControlEscMap:start({timeout: 0.2})
+spoon.ControlEscMap:start({timeout = 0.2})
 ```
 
 # Configuration


### PR DESCRIPTION
@chriszarate It should be `=` instead of `:`